### PR TITLE
Added the drink removal function.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,10 +1,9 @@
-
 plugins {
     id("com.android.application")
     id("kotlin-android")
     id("kotlin-android-extensions")
     id("androidx.navigation.safeargs.kotlin")
-
+    id("kotlin-kapt")
 }
 
 android {
@@ -52,6 +51,24 @@ dependencies {
     // Navigation (Kotlin)
     implementation( "androidx.navigation:navigation-fragment-ktx:2.1.0")
     implementation( "androidx.navigation:navigation-ui-ktx:2.1.0")
+
+
+    val lifecycle_version = "2.1.0"
+
+    // ViewModel and LiveData
+    implementation("androidx.lifecycle:lifecycle-extensions:$lifecycle_version")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.2.0-rc03")
+    implementation("androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version")
+
+    kapt("androidx.lifecycle:lifecycle-compiler:$lifecycle_version") // For Kotlin use kapt instead of annotationProcessor
+
+    // optional - ReactiveStreams support for LiveData
+    implementation("androidx.lifecycle:lifecycle-reactivestreams-ktx:$lifecycle_version") // For Kotlin use lifecycle-reactivestreams-ktx
+
+    // optional - Test helpers for LiveData
+    testImplementation("androidx.arch.core:core-testing:$lifecycle_version")
+
 }
 
 tasks.withType<Test> {

--- a/app/src/main/java/com/vaudibert/canidrive/domain/Drinker.kt
+++ b/app/src/main/java/com/vaudibert/canidrive/domain/Drinker.kt
@@ -69,4 +69,8 @@ class Drinker(var weight: Double = 80.0, var sex: String = "NONE") {
     }
 
     fun getDrinks() = ArrayList(absorbedDrinks)
+
+    fun remove(drink: AbsorbedDrink) {
+        absorbedDrinks.remove(drink)
+    }
 }

--- a/app/src/main/java/com/vaudibert/canidrive/ui/AddDrinkFragment.kt
+++ b/app/src/main/java/com/vaudibert/canidrive/ui/AddDrinkFragment.kt
@@ -12,7 +12,6 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.vaudibert.canidrive.R
 import com.vaudibert.canidrive.domain.Drink
-import com.vaudibert.canidrive.domain.Drinker
 import kotlinx.android.synthetic.main.fragment_add_drink.*
 import java.util.*
 
@@ -20,8 +19,6 @@ import java.util.*
  * Fragment to add a drink.
  */
 class AddDrinkFragment : Fragment() {
-
-    lateinit var drinker: Drinker
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -34,15 +31,13 @@ class AddDrinkFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        drinker = (this.activity as MainActivity).drinker
-
         buttonValidateNewDrink.setOnClickListener {
             try {
                 var quantity = editTextQuantity.text.toString().toInt()
                 var degree = editTextDegree.text.toString().toFloat()
                 var ingestionTime = Date(Date().time - (editTextBefore.text.toString().toLong() * 60000))
 
-                drinker.ingest(
+                DrinkerRepository.ingest(
                     Drink(
                         quantity,
                         degree

--- a/app/src/main/java/com/vaudibert/canidrive/ui/DrinkerFragment.kt
+++ b/app/src/main/java/com/vaudibert/canidrive/ui/DrinkerFragment.kt
@@ -12,15 +12,12 @@ import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.vaudibert.canidrive.R
-import com.vaudibert.canidrive.domain.Drinker
 import kotlinx.android.synthetic.main.fragment_drinker.*
 
 /**
  * The drinker fragment to enter its details.
  */
 class DrinkerFragment : Fragment() {
-
-    lateinit var drinker: Drinker
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -34,13 +31,19 @@ class DrinkerFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        drinker = (this.activity as MainActivity).drinker
+        editTextWeight.setText(DrinkerRepository.getWeight().toString())
+        val sex = DrinkerRepository.getSex()
+        radioGroupSex.check(when (sex) {
+            "MALE" -> R.id.radioButtonMale
+            "FEMALE" -> R.id.radioButtonFemale
+            else -> R.id.radioButtonOther
+        })
 
         editTextWeight.setOnFocusChangeListener { _, hasFocus ->
             run {
                 if (!hasFocus)
                     try {
-                        drinker.weight = editTextWeight.text.toString().toDouble()
+                        DrinkerRepository.setWeight(editTextWeight.text.toString().toDouble())
                     } catch (e:Exception) {
                         longToast("You did not correctly fill your weight \nPlease try again")
                         return@setOnFocusChangeListener
@@ -51,10 +54,12 @@ class DrinkerFragment : Fragment() {
         radioGroupSex.setOnCheckedChangeListener {
                 _,
                 checkedId ->
-            drinker.sex = if (checkedId != -1)
-                view.findViewById<RadioButton>(checkedId).text.toString().toUpperCase()
-            else
-                "NONE"
+            DrinkerRepository.setSex(
+                if (checkedId != -1)
+                    view.findViewById<RadioButton>(checkedId).text.toString().toUpperCase()
+                else
+                    "NONE"
+            )
         }
 
         buttonValidateDrinker.setOnClickListener {

--- a/app/src/main/java/com/vaudibert/canidrive/ui/DrinkerRepository.kt
+++ b/app/src/main/java/com/vaudibert/canidrive/ui/DrinkerRepository.kt
@@ -1,0 +1,45 @@
+package com.vaudibert.canidrive.ui
+
+import androidx.lifecycle.MutableLiveData
+import com.vaudibert.canidrive.domain.AbsorbedDrink
+import com.vaudibert.canidrive.domain.Drink
+import com.vaudibert.canidrive.domain.Drinker
+import java.util.*
+
+object DrinkerRepository {
+    private var drinker = Drinker()
+
+    val liveDrinker = MutableLiveData<Drinker>(drinker)
+
+    fun setDrinker(drinker: Drinker) {
+        this.drinker = drinker
+        liveDrinker.value = drinker
+    }
+
+    fun remove(drink: AbsorbedDrink) {
+        drinker.remove(drink)
+        liveDrinker.value = drinker
+    }
+
+    fun ingest(drink : Drink, ingestionTime : Date) {
+        drinker.ingest(drink, ingestionTime)
+        liveDrinker.value = drinker
+    }
+
+    fun setWeight(weight: Double) {
+        drinker.weight = weight
+        liveDrinker.value = drinker
+    }
+
+    fun setSex(sex: String) {
+        drinker.sex = sex
+        liveDrinker.value = drinker
+    }
+
+    fun getDrinks() = drinker.getDrinks()
+
+    fun getWeight() = drinker.weight
+
+    fun getSex() = drinker.sex
+
+}

--- a/app/src/main/java/com/vaudibert/canidrive/ui/MainActivity.kt
+++ b/app/src/main/java/com/vaudibert/canidrive/ui/MainActivity.kt
@@ -9,11 +9,13 @@ import com.vaudibert.canidrive.domain.Drinker
 
 class MainActivity : AppCompatActivity() {
 
-    val drinker = Drinker()
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        // TODO : insert sharedpref reading here to fill the repository
+        DrinkerRepository.setDrinker(Drinker())
+
     }
 
 

--- a/app/src/main/java/com/vaudibert/canidrive/ui/PastDrinksAdapter.kt
+++ b/app/src/main/java/com/vaudibert/canidrive/ui/PastDrinksAdapter.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.BaseAdapter
+import android.widget.ImageButton
 import android.widget.TextView
 import com.vaudibert.canidrive.R
 import com.vaudibert.canidrive.domain.AbsorbedDrink
@@ -12,37 +13,52 @@ import java.text.SimpleDateFormat
 
 class PastDrinksAdapter(
     context: Context,
-    private val drinks:ArrayList<AbsorbedDrink>) : BaseAdapter() {
+    private var drinkList : List<AbsorbedDrink>
+    ) : BaseAdapter() {
 
     private val inflater: LayoutInflater =
         context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
 
-    val dateFormat = SimpleDateFormat("HH:mm")
+    private val dateFormat = SimpleDateFormat("HH:mm")
 
     override fun getView(position: Int, convertView: View?, parent: ViewGroup?): View {
 
         val drinkView = inflater.inflate(R.layout.item_past_drink, parent, false)
+        val drink = getItem(position)
 
         val quantityText = drinkView.findViewById(R.id.pastDrinkTextQuantity) as TextView
         val degreeText = drinkView.findViewById(R.id.pastDrinkTextDegree) as TextView
         val timeText = drinkView.findViewById(R.id.pastDrinkTextTime) as TextView
 
-        val drink = getItem(position)
-
         quantityText.text = "${drink.qtyMilliLiter} ml"
         degreeText.text = "${drink.degree} %"
         timeText.text = dateFormat.format(drink.ingestionTime)
+
+        val buttonRemovePastDrink =
+            drinkView.findViewById(R.id.buttonRemovePastDrink) as ImageButton
+
+        buttonRemovePastDrink.setOnClickListener {
+            DrinkerRepository.remove(drink)
+            notifyDataSetInvalidated()
+        }
 
         return drinkView
     }
 
     override fun getItem(position: Int): AbsorbedDrink {
-        return drinks[position]
+        return drinkList[position]
     }
 
     override fun getItemId(position: Int): Long {
         return position.toLong()
     }
 
-    override fun getCount(): Int = drinks.size
+    override fun getCount(): Int {
+        return drinkList.size
+    }
+
+    fun setDrinkList(drinks : List<AbsorbedDrink>) {
+        drinkList = drinks
+        notifyDataSetChanged()
+    }
 }


### PR DESCRIPTION
This required to rework the drinker data hosting, now in a singleton
repository (not great, to improve later, see #42).

A temporary implementation used a view model, but it was removed as of
little use and redundant. The dependencies were kept though (see #43).

The DrinkerFragment is now updated with the previous (or default for now) values, coming from the DrinkerRepository. The retrieval of values from previous session is still to do.

Fixed #38